### PR TITLE
Build docker images on GH and push to DockerHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 
 on:
     release:
-        types: [published]
+        types: [ published ]
 
 jobs:
     upload:
@@ -13,30 +13,84 @@ jobs:
         # Steps represent a sequence of tasks that will be executed as part of the job
         steps:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-            - uses: actions/checkout@v2
-            - uses: actions/setup-java@v1
-              with:
-                  java-version: 11
+            -   uses: actions/checkout@v2
+            -   uses: actions/setup-java@v1
+                with:
+                    java-version: 11
 
-            - name: Cache
-              uses: actions/cache@v2.0.0
-              with:
-                  # A list of files, directories, and wildcard patterns to cache and restore
-                  path: |
-                      ~/.gradle/caches/jars-3
-                      ~/.gradle/caches/modules-2/files-2.1/
-                      ~/.gradle/caches/modules-2/metadata-2.96/
-                      ~/.gradle/native
-                      ~/.gradle/wrapper
-                  # An explicit key for restoring and saving the cache
-                  key: ${{ runner.os }}-gradle
+            -   name: Cache
+                uses: actions/cache@v2.0.0
+                with:
+                    # A list of files, directories, and wildcard patterns to cache and restore
+                    path: |
+                        ~/.gradle/caches/jars-3
+                        ~/.gradle/caches/modules-2/files-2.1/
+                        ~/.gradle/caches/modules-2/metadata-2.96/
+                        ~/.gradle/native
+                        ~/.gradle/wrapper
+                    # An explicit key for restoring and saving the cache
+                    key: ${{ runner.os }}-gradle
 
             # Compile code
-            - name: Compile code
-              run: ./gradlew assemble
+            -   name: Compile code
+                run: ./gradlew assemble
             # Upload it to GitHub
-            - name: Upload to GitHub
-              uses: AButler/upload-release-assets@v2.0
-              with:
-                  files: 'build/libs/*;build/distributions/*'
-                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+            -   name: Upload to GitHub
+                uses: AButler/upload-release-assets@v2.0
+                with:
+                    files: 'build/libs/*;build/distributions/*'
+                    repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    # Build and push tagged release docker image
+    docker:
+        # The type of runner that the job will run on
+        runs-on: ubuntu-latest
+
+        env:
+            DOCKER_IMAGE: covidcollab/radar-push-endpoint
+
+        # Steps represent a sequence of tasks that will be executed as part of the job
+        steps:
+            -   uses: actions/checkout@v2
+
+            # Setup docker build environment
+            -   name: Set up QEMU
+                uses: docker/setup-qemu-action@v1
+
+            -   name: Set up Docker Buildx
+                uses: docker/setup-buildx-action@v1
+
+            -   name: Login to DockerHub
+                uses: docker/login-action@v1
+                with:
+                    username: ${{ secrets.DOCKERHUB_USERNAME }}
+                    password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            # Add Docker labels and tags
+            -   name: Docker meta
+                id: docker_meta
+                uses: crazy-max/ghaction-docker-meta@v2
+                with:
+                    images: ${{ env.DOCKER_IMAGE }}
+                    tags: |
+                        type=semver,pattern={{version}}
+                        type=semver,pattern={{major}}.{{minor}}
+            -   name: Build docker
+                uses: docker/build-push-action@v2
+                with:
+                    # Allow running the image on the architectures supported by openjdk:11-jre-slim
+                    platforms: linux/amd64,linux/arm64
+                    push: true
+                    tags: ${{ steps.docker_meta.outputs.tags }}
+                    # Use runtime labels from docker_meta as well as fixed labels
+                    labels: |
+                        ${{ steps.docker_meta.outputs.labels }}
+                        maintainer=Yatharth Ranjan <yatharth.ranjan@kcl.ac.uk>, Pauline Conde <pauline.conde@kcl.ac.uk>
+                        org.opencontainers.image.description=RADAR-base Push Endpoint
+                        org.opencontainers.image.authors=Yatharth Ranjan <yatharth.ranjan@kcl.ac.uk>, Pauline Conde <pauline.conde@kcl.ac.uk>
+                        org.opencontainers.image.vendor=RADAR-base
+                        org.opencontainers.image.licenses=Apache-2.0
+            -   name: Inspect docker image
+                run: |
+                    docker pull ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}
+                    docker image inspect ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}


### PR DESCRIPTION
Docker hub is not allowing Automated builds on free accounts anymore, so building in GH actions