### PR TITLE
update moveIQ backfill limit to 2 years

### DIFF
--- a/src/main/kotlin/org/radarbase/push/integration/garmin/backfill/route/GarminMoveIQRoute.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/garmin/backfill/route/GarminMoveIQRoute.kt
@@ -14,6 +14,6 @@ class GarminMoveIQRoute(
 
     override fun maxBackfillPeriod(): Duration {
         // 2 years default. Activity API routes will override this with 5 years
-        return Duration.ofDays(365 * 5)
+        return Duration.ofDays(365 * 2)
     }
 }


### PR DESCRIPTION
Apparently, moveIQ is part of the Activity API but still has only a 2 year backfill limit. 